### PR TITLE
support that `uuid.NewV4()` returns multiple values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 
 go:
-  - 1.6
+  - 1.8
+  - 1.10.2
   - tip

--- a/edgegrid/auth.go
+++ b/edgegrid/auth.go
@@ -29,13 +29,14 @@ type AuthParams struct {
 // NewAuthParams returns an AuthParams generated from req, accessToken,
 // clientToken, and clientSecret.
 func NewAuthParams(req *http.Request, accessToken, clientToken, clientSecret string) AuthParams {
+	id, _ := uuid.NewV4()
 	return AuthParams{
 		req,
 		clientToken,
 		accessToken,
 		clientSecret,
 		time.Now().UTC().Format("20060102T15:04:05+0000"),
-		uuid.NewV4().String(),
+		id.String(),
 		[]string{},
 	}
 }


### PR DESCRIPTION
This seeks to avoid the following compilation error,
as `uuid.NewV4()` returns multiple values.

```
make test
go test ./... -cover
edgegrid/auth.go:38: multiple-value uuid.NewV4() in single-value context
FAIL    github.com/comcast/go-edgegrid/edgegrid [build failed]
make: *** [test] Error 2
```